### PR TITLE
Oil generator fixing

### DIFF
--- a/modules/rtcs/gen/inc/Rtcs_Cfg.h.php
+++ b/modules/rtcs/gen/inc/Rtcs_Cfg.h.php
@@ -62,18 +62,18 @@
 /*==================[external functions declaration]=========================*/
 <?php
 /* get controllers */
-$controllers = $config->getList("/RTCS","StateFeedback");
+$controllers = $this->config->getList("/RTCS","StateFeedback");
 ?>
 <?php
 $count = 0;
 foreach ($controllers as $controller)
 {
 ?>
-/** \brief User's function that should be called every <?=$config->getValue("/RTCS/" . $controller, "PERIOD")?>ms
+/** \brief User's function that should be called every <?=$this->config->getValue("/RTCS/" . $controller, "PERIOD")?>ms
  **
  ** Public function that executes the controller of the <?=$controller;?> system
  **/
-void Rtcs_<?=$controller;?>_<?=$config->getValue("/RTCS/" . $controller, "PERIOD")?>ms (void);
+void Rtcs_<?=$controller;?>_<?=$this->config->getValue("/RTCS/" . $controller, "PERIOD")?>ms (void);
 
 <?php
 $count++;
@@ -85,11 +85,11 @@ foreach ($controllers as $controller)
 {
 ?>
 <?php
-$system_type = $config->getValue("/RTCS/" . $controller, "SYSTEM_TYPE");
+$system_type = $this->config->getValue("/RTCS/" . $controller, "SYSTEM_TYPE");
 if ($system_type == "CONTROL_SYSTEM"): ?>
 <?php
 $subcount = 0;
-$subcount_max = $config->getValue("/RTCS/" . $controller, "X_SIZE");
+$subcount_max = $this->config->getValue("/RTCS/" . $controller, "X_SIZE");
 while ($subcount < $subcount_max)
 {
 ?>
@@ -108,7 +108,7 @@ $subcount++;
 <?php endif ?>
 <?php
 $subcount = 0;
-$subcount_max = $config->getValue("/RTCS/" . $controller, "Y_SIZE");
+$subcount_max = $this->config->getValue("/RTCS/" . $controller, "Y_SIZE");
 while ($subcount < $subcount_max)
 {
 ?>

--- a/modules/rtcs/gen/inc/Rtcs_Internal_Cfg.h.php
+++ b/modules/rtcs/gen/inc/Rtcs_Internal_Cfg.h.php
@@ -61,7 +61,7 @@ extern "C" {
 /*==================[macros]=================================================*/
 <?php
 /* get controllers */
-$controllers = $config->getList("/RTCS","StateFeedback");
+$controllers = $this->config->getList("/RTCS","StateFeedback");
 ?>
 /* Size of the controller list */
 #define CONTROLLERS_LIST_SIZE <?=count($controllers);?>

--- a/modules/rtcs/gen/src/Rtcs_Cfg.c.php
+++ b/modules/rtcs/gen/src/Rtcs_Cfg.c.php
@@ -50,7 +50,7 @@
 /*==================[inclusions]=============================================*/
 #include "Rtcs_Internal.h"
 <?php
-$pdefs = $config->getList("/RTCS","INCLUDE_FILE");
+$pdefs = $this->config->getList("/RTCS","INCLUDE_FILE");
 $count = 1;
 foreach ($pdefs as $pdef)
 {
@@ -75,7 +75,7 @@ foreach ($pdefs as $pdef)
 /*==================[external functions definition]==========================*/
 <?php
 /* get controllers */
-$controllers = $config->getList("/RTCS","StateFeedback");
+$controllers = $this->config->getList("/RTCS","StateFeedback");
 ?>
 <?php
 $count = 0;
@@ -83,7 +83,7 @@ foreach ($controllers as $controller)
 {
 ?>
 /* Public function that executes the controller of the <?=$controller;?> system */
-extern void Rtcs_<?=$controller;?>_<?=$config->getValue("/RTCS/" . $controller, "PERIOD")?>ms (void)
+extern void Rtcs_<?=$controller;?>_<?=$this->config->getValue("/RTCS/" . $controller, "PERIOD")?>ms (void)
 {
    if(Rtcs_state == ACTIVE)
    {
@@ -101,11 +101,11 @@ foreach ($controllers as $controller)
 {
 ?>
 <?php
-$system_type = $config->getValue("/RTCS/" . $controller, "SYSTEM_TYPE");
+$system_type = $this->config->getValue("/RTCS/" . $controller, "SYSTEM_TYPE");
 if ($system_type == "CONTROL_SYSTEM"): ?>
 <?php
 $subcount = 0;
-$subcount_max = $config->getValue("/RTCS/" . $controller, "X_SIZE");
+$subcount_max = $this->config->getValue("/RTCS/" . $controller, "X_SIZE");
 while ($subcount < $subcount_max)
 {
 ?>
@@ -123,7 +123,7 @@ $subcount++;
 <?php endif ?>
 <?php
 $subcount = 0;
-$subcount_max = $config->getValue("/RTCS/" . $controller, "Y_SIZE");
+$subcount_max = $this->config->getValue("/RTCS/" . $controller, "Y_SIZE");
 while ($subcount < $subcount_max)
 {
 ?>
@@ -148,7 +148,7 @@ foreach ($controllers as $controller)
 {
 ?>
 /* Public function that executes the "worst case" of the controller of the <?=$controller;?> system */
-extern void Rtcs_WorstCase_<?=$controller;?>_<?=$config->getValue("/RTCS/" . $controller, "PERIOD")?>ms (void)
+extern void Rtcs_WorstCase_<?=$controller;?>_<?=$this->config->getValue("/RTCS/" . $controller, "PERIOD")?>ms (void)
 {
    if(Rtcs_state == ACTIVE)
    {

--- a/modules/rtcs/gen/src/Rtcs_Internal_Cfg.c.php
+++ b/modules/rtcs/gen/src/Rtcs_Internal_Cfg.c.php
@@ -50,7 +50,7 @@
 /*==================[inclusions]=============================================*/
 #include "Rtcs_Internal.h"
 <?php
-$pdefs = $config->getList("/RTCS","INCLUDE_FILE");
+$pdefs = $this->config->getList("/RTCS","INCLUDE_FILE");
 $count = 1;
 foreach ($pdefs as $pdef)
 {
@@ -71,7 +71,7 @@ foreach ($pdefs as $pdef)
 /*==================[external data definition]===============================*/
 <?php
 /* get controllers */
-$controllers = $config->getList("/RTCS","StateFeedback");
+$controllers = $this->config->getList("/RTCS","StateFeedback");
 
 /* configuation loop for each controller */
 $count = 1;
@@ -81,102 +81,102 @@ foreach ($controllers as $controller)
    /* The system may be "CONTROL_SYSTEM" or "REGULATOR" */
    /* The observer may be "NONE", "FULL" or "REDUCED" */
    /* So there are 6 (six) posibilities, there are 6 six if() sentences */
-   $system_type = $config->getValue("/RTCS/" . $controller, "SYSTEM_TYPE");
-   $observer_type = $config->getValue("/RTCS/" . $controller, "OBSERVER_TYPE");
+   $system_type = $this->config->getValue("/RTCS/" . $controller, "SYSTEM_TYPE");
+   $observer_type = $this->config->getValue("/RTCS/" . $controller, "OBSERVER_TYPE");
 
    /* print comments about system and observer types */
    print "\n";
    print "/* Data definition of the closed loop system named " . $controller . " */\n";
-   print "/* SYSTEM_TYPE = " . $config->getValue("/RTCS/" . $controller, "SYSTEM_TYPE") . " - OBSERVER_TYPE = " . $config->getValue("/RTCS/" . $controller, "OBSERVER_TYPE") . " */\n";
+   print "/* SYSTEM_TYPE = " . $this->config->getValue("/RTCS/" . $controller, "SYSTEM_TYPE") . " - OBSERVER_TYPE = " . $this->config->getValue("/RTCS/" . $controller, "OBSERVER_TYPE") . " */\n";
 
    ?>
 <?php
    /* system configuration if the system is "CONTROL_SYSTEM" and observer is "NONE" */
    if ($system_type == "CONTROL_SYSTEM" && $observer_type == "NONE"): ?>
-<?    ?>float r_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
-<?    ?>float x_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
-<?    ?>float e_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
-<?    ?>float y_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
-<?    ?>float u_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "U_SIZE")?>];
-<?    ?>float k_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>] = {<?=$config->getValue("/RTCS/" . $controller, "K_MATRIX")?>};
+<?    ?>float r_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
+<?    ?>float x_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
+<?    ?>float e_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
+<?    ?>float y_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
+<?    ?>float u_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "U_SIZE")?>];
+<?    ?>float k_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>] = {<?=$this->config->getValue("/RTCS/" . $controller, "K_MATRIX")?>};
 <?    ?>Rtcs_ext_matrix_t matrix_array_<?=$count;?>[6];
-<?    ?>Rtcs_statefeedback_data_t controller_<?=$count;?> = {CONTROL_SYSTEM, NONE, <?=$config->getValue("/RTCS/" . $controller, "PERIOD")?>, <?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>, <?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>, <?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>, <?=$config->getValue("/RTCS/" . $controller, "U_SIZE")?>, <?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>, r_data_<?=$count?>, x_data_<?=$count?>, 0, e_data_<?=$count;?>, u_data_<?=$count;?>, y_data_<?=$count;?>, k_data_<?=$count;?>, 0, 0, 0, 0, 0, 0, 0, &matrix_array_<?=$count;?>[0], &matrix_array_<?=$count?>[1], 0, &matrix_array_<?=$count?>[2], &matrix_array_<?=$count?>[3], &matrix_array_<?=$count?>[4], &matrix_array_<?=$count?>[5], 0, 0, 0, 0, 0, 0, 0, <?=$config->getValue("/RTCS/" . $controller, "SEND_FUNCTION")?>, Rtcs_ControlSystemEffort, Rtcs_NoneObserver};
+<?    ?>Rtcs_statefeedback_data_t controller_<?=$count;?> = {CONTROL_SYSTEM, NONE, <?=$this->config->getValue("/RTCS/" . $controller, "PERIOD")?>, <?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>, <?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>, <?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>, <?=$this->config->getValue("/RTCS/" . $controller, "U_SIZE")?>, <?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>, r_data_<?=$count?>, x_data_<?=$count?>, 0, e_data_<?=$count;?>, u_data_<?=$count;?>, y_data_<?=$count;?>, k_data_<?=$count;?>, 0, 0, 0, 0, 0, 0, 0, &matrix_array_<?=$count;?>[0], &matrix_array_<?=$count?>[1], 0, &matrix_array_<?=$count?>[2], &matrix_array_<?=$count?>[3], &matrix_array_<?=$count?>[4], &matrix_array_<?=$count?>[5], 0, 0, 0, 0, 0, 0, 0, <?=$this->config->getValue("/RTCS/" . $controller, "SEND_FUNCTION")?>, Rtcs_ControlSystemEffort, Rtcs_NoneObserver};
 <?php endif
 
    ?>
 <?php
    /* system configuration if the system is "CONTROL_SYSTEM" and observer is "FULL" */
    if ($system_type == "CONTROL_SYSTEM" && $observer_type == "FULL"): ?>
-<?    ?>float r_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
-<?    ?>float x_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
-<?    ?>float xo_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
-<?    ?>float e_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
-<?    ?>float u_y_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "U_SIZE")?> + <?=$config->getValue("/RTCS/" . $controller, "Y_SIZE")?>];
-<?    ?>float k_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>] = {<?=$config->getValue("/RTCS/" . $controller, "K_MATRIX")?>};
-<?    ?>float mf_data_<?=$count;?>[] = {<?=$config->getValue("/RTCS/" . $controller, "FUND_MATRIX")?>};
-<?    ?>float mt_data_<?=$count;?>[] = {<?=$config->getValue("/RTCS/" . $controller, "TRAN_MATRIX")?>};
+<?    ?>float r_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
+<?    ?>float x_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
+<?    ?>float xo_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
+<?    ?>float e_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
+<?    ?>float u_y_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "U_SIZE")?> + <?=$this->config->getValue("/RTCS/" . $controller, "Y_SIZE")?>];
+<?    ?>float k_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>] = {<?=$this->config->getValue("/RTCS/" . $controller, "K_MATRIX")?>};
+<?    ?>float mf_data_<?=$count;?>[] = {<?=$this->config->getValue("/RTCS/" . $controller, "FUND_MATRIX")?>};
+<?    ?>float mt_data_<?=$count;?>[] = {<?=$this->config->getValue("/RTCS/" . $controller, "TRAN_MATRIX")?>};
 <?    ?>Rtcs_ext_matrix_t matrix_array_<?=$count;?>[10];
-<?    ?>Rtcs_statefeedback_data_t controller_<?=$count;?> = {CONTROL_SYSTEM, FULL, <?=$config->getValue("/RTCS/" . $controller, "PERIOD")?>, <?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>, <?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>, <?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>, <?=$config->getValue("/RTCS/" . $controller, "U_SIZE")?>, <?=$config->getValue("/RTCS/" . $controller, "Y_SIZE")?>, r_data_<?=$count?>, x_data_<?=$count?>, xo_data_<?=$count;?>, e_data_<?=$count;?>, u_y_data_<?=$count;?>, &(u_y_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "U_SIZE")?>]),k_data_<?=$count;?>, u_y_data_<?=$count;?>, 0, 0, 0, mf_data_<?=$count;?>, mt_data_<?=$count;?>, 0, &matrix_array_<?=$count;?>[0], &matrix_array_<?=$count?>[1], &matrix_array_<?=$count?>[2], &matrix_array_<?=$count?>[3], &matrix_array_<?=$count?>[4], &matrix_array_<?=$count?>[5], &matrix_array_<?=$count?>[6], &matrix_array_<?=$count?>[7], 0, 0, 0, &matrix_array_<?=$count?>[8], &matrix_array_<?=$count?>[9], 0, <?=$config->getValue("/RTCS/" . $controller, "SEND_FUNCTION")?>, Rtcs_ControlSystemEffort, Rtcs_FullObserver};
+<?    ?>Rtcs_statefeedback_data_t controller_<?=$count;?> = {CONTROL_SYSTEM, FULL, <?=$this->config->getValue("/RTCS/" . $controller, "PERIOD")?>, <?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>, <?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>, <?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>, <?=$this->config->getValue("/RTCS/" . $controller, "U_SIZE")?>, <?=$this->config->getValue("/RTCS/" . $controller, "Y_SIZE")?>, r_data_<?=$count?>, x_data_<?=$count?>, xo_data_<?=$count;?>, e_data_<?=$count;?>, u_y_data_<?=$count;?>, &(u_y_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "U_SIZE")?>]),k_data_<?=$count;?>, u_y_data_<?=$count;?>, 0, 0, 0, mf_data_<?=$count;?>, mt_data_<?=$count;?>, 0, &matrix_array_<?=$count;?>[0], &matrix_array_<?=$count?>[1], &matrix_array_<?=$count?>[2], &matrix_array_<?=$count?>[3], &matrix_array_<?=$count?>[4], &matrix_array_<?=$count?>[5], &matrix_array_<?=$count?>[6], &matrix_array_<?=$count?>[7], 0, 0, 0, &matrix_array_<?=$count?>[8], &matrix_array_<?=$count?>[9], 0, <?=$this->config->getValue("/RTCS/" . $controller, "SEND_FUNCTION")?>, Rtcs_ControlSystemEffort, Rtcs_FullObserver};
 <?php endif
 
    ?>
 <?php
    /* system configuration if the system is "CONTROL_SYSTEM" and observer is "REDUCED" */
    if ($system_type == "CONTROL_SYSTEM" && $observer_type == "REDUCED"): ?>
-<?    ?>float r_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
-<?    ?>float x_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
-<?    ?>float xo_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?> - <?=$config->getValue("/RTCS/" . $controller, "Y_SIZE")?>];
-<?    ?>float e_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
-<?    ?>float y_u_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "Y_SIZE")?> + <?=$config->getValue("/RTCS/" . $controller, "U_SIZE")?>];
-<?    ?>float k_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>] = {<?=$config->getValue("/RTCS/" . $controller, "K_MATRIX")?>};
-<?    ?>float l_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?> - <?=$config->getValue("/RTCS/" . $controller, "Y_SIZE")?>] = {<?=$config->getValue("/RTCS/" . $controller, "L_MATRIX")?>};
-<?    ?>float mf_data_<?=$count;?>[] = {<?=$config->getValue("/RTCS/" . $controller, "FUND_MATRIX")?>};
-<?    ?>float mt_data_<?=$count;?>[] = {<?=$config->getValue("/RTCS/" . $controller, "TRAN_MATRIX")?>};
-<?    ?>float xo_aux_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?> - <?=$config->getValue("/RTCS/" . $controller, "Y_SIZE")?>];
+<?    ?>float r_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
+<?    ?>float x_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
+<?    ?>float xo_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?> - <?=$this->config->getValue("/RTCS/" . $controller, "Y_SIZE")?>];
+<?    ?>float e_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
+<?    ?>float y_u_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "Y_SIZE")?> + <?=$this->config->getValue("/RTCS/" . $controller, "U_SIZE")?>];
+<?    ?>float k_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>] = {<?=$this->config->getValue("/RTCS/" . $controller, "K_MATRIX")?>};
+<?    ?>float l_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?> - <?=$this->config->getValue("/RTCS/" . $controller, "Y_SIZE")?>] = {<?=$this->config->getValue("/RTCS/" . $controller, "L_MATRIX")?>};
+<?    ?>float mf_data_<?=$count;?>[] = {<?=$this->config->getValue("/RTCS/" . $controller, "FUND_MATRIX")?>};
+<?    ?>float mt_data_<?=$count;?>[] = {<?=$this->config->getValue("/RTCS/" . $controller, "TRAN_MATRIX")?>};
+<?    ?>float xo_aux_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?> - <?=$this->config->getValue("/RTCS/" . $controller, "Y_SIZE")?>];
 <?    ?>Rtcs_ext_matrix_t matrix_array_<?=$count;?>[12];
-<?    ?>Rtcs_statefeedback_data_t controller_<?=$count;?> = {CONTROL_SYSTEM, REDUCED, <?=$config->getValue("/RTCS/" . $controller, "PERIOD")?>, <?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>, <?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>, <?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>, <?=$config->getValue("/RTCS/" . $controller, "U_SIZE")?>, <?=$config->getValue("/RTCS/" . $controller, "Y_SIZE")?>, r_data_<?=$count?>, x_data_<?=$count?>, xo_data_<?=$count;?>, e_data_<?=$count;?>, &(y_u_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "Y_SIZE")?>]), y_u_data_<?=$count;?>,k_data_<?=$count;?>, y_u_data_<?=$count;?>, 0, 0, l_data_<?=$count;?>, mf_data_<?=$count;?>, mt_data_<?=$count;?>, xo_aux_data_<?=$count;?>, &matrix_array_<?=$count;?>[0], &matrix_array_<?=$count?>[1], &matrix_array_<?=$count?>[2], &matrix_array_<?=$count?>[3], &matrix_array_<?=$count?>[4], &matrix_array_<?=$count?>[5], &matrix_array_<?=$count?>[6], &matrix_array_<?=$count?>[7], 0, 0, &matrix_array_<?=$count?>[8], &matrix_array_<?=$count?>[9], &matrix_array_<?=$count?>[10], &matrix_array_<?=$count?>[11], <?=$config->getValue("/RTCS/" . $controller, "SEND_FUNCTION")?>, Rtcs_ControlSystemEffort, Rtcs_ReducedObserver};
+<?    ?>Rtcs_statefeedback_data_t controller_<?=$count;?> = {CONTROL_SYSTEM, REDUCED, <?=$this->config->getValue("/RTCS/" . $controller, "PERIOD")?>, <?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>, <?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>, <?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>, <?=$this->config->getValue("/RTCS/" . $controller, "U_SIZE")?>, <?=$this->config->getValue("/RTCS/" . $controller, "Y_SIZE")?>, r_data_<?=$count?>, x_data_<?=$count?>, xo_data_<?=$count;?>, e_data_<?=$count;?>, &(y_u_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "Y_SIZE")?>]), y_u_data_<?=$count;?>,k_data_<?=$count;?>, y_u_data_<?=$count;?>, 0, 0, l_data_<?=$count;?>, mf_data_<?=$count;?>, mt_data_<?=$count;?>, xo_aux_data_<?=$count;?>, &matrix_array_<?=$count;?>[0], &matrix_array_<?=$count?>[1], &matrix_array_<?=$count?>[2], &matrix_array_<?=$count?>[3], &matrix_array_<?=$count?>[4], &matrix_array_<?=$count?>[5], &matrix_array_<?=$count?>[6], &matrix_array_<?=$count?>[7], 0, 0, &matrix_array_<?=$count?>[8], &matrix_array_<?=$count?>[9], &matrix_array_<?=$count?>[10], &matrix_array_<?=$count?>[11], <?=$this->config->getValue("/RTCS/" . $controller, "SEND_FUNCTION")?>, Rtcs_ControlSystemEffort, Rtcs_ReducedObserver};
 <?php endif
 
    ?>
 <?php
    /* system configuration if the system is "REGULATOR" and observer is "NONE" */
    if ($system_type == "REGULATOR" && $observer_type == "NONE"): ?>
-<?    ?>float x_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
-<?    ?>float y_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
-<?    ?>float u_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "U_SIZE")?>];
-<?    ?>float k_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>] = {<?=$config->getValue("/RTCS/" . $controller, "K_MATRIX")?>};
+<?    ?>float x_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
+<?    ?>float y_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
+<?    ?>float u_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "U_SIZE")?>];
+<?    ?>float k_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>] = {<?=$this->config->getValue("/RTCS/" . $controller, "K_MATRIX")?>};
 <?    ?>Rtcs_ext_matrix_t matrix_array_<?=$count;?>[4];
-<?    ?>Rtcs_statefeedback_data_t controller_<?=$count;?> = {REGULATOR, NONE, <?=$config->getValue("/RTCS/" . $controller, "PERIOD")?>, 0, <?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>, 0, <?=$config->getValue("/RTCS/" . $controller, "U_SIZE")?>, <?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>, 0, x_data_<?=$count?>, 0, 0, u_data_<?=$count;?>, y_data_<?=$count;?>, k_data_<?=$count;?>, 0, 0, 0, 0, 0, 0, 0, 0, &matrix_array_<?=$count?>[0], 0, 0, &matrix_array_<?=$count?>[1], &matrix_array_<?=$count?>[2], &matrix_array_<?=$count?>[3], 0, 0, 0, 0, 0, 0, 0, <?=$config->getValue("/RTCS/" . $controller, "SEND_FUNCTION")?>, Rtcs_RegulatorControlEffort, Rtcs_NoneObserver};
+<?    ?>Rtcs_statefeedback_data_t controller_<?=$count;?> = {REGULATOR, NONE, <?=$this->config->getValue("/RTCS/" . $controller, "PERIOD")?>, 0, <?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>, 0, <?=$this->config->getValue("/RTCS/" . $controller, "U_SIZE")?>, <?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>, 0, x_data_<?=$count?>, 0, 0, u_data_<?=$count;?>, y_data_<?=$count;?>, k_data_<?=$count;?>, 0, 0, 0, 0, 0, 0, 0, 0, &matrix_array_<?=$count?>[0], 0, 0, &matrix_array_<?=$count?>[1], &matrix_array_<?=$count?>[2], &matrix_array_<?=$count?>[3], 0, 0, 0, 0, 0, 0, 0, <?=$this->config->getValue("/RTCS/" . $controller, "SEND_FUNCTION")?>, Rtcs_RegulatorControlEffort, Rtcs_NoneObserver};
 <?php endif
 
    ?>
 <?php
    /* system configuration if the system is "REGULATOR" and observer is "FULL" */
 if ($system_type == "REGULATOR" && $observer_type == "FULL"): ?>
-<?    ?>float x_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
-<?    ?>float xo_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
-<?    ?>float u_y_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "U_SIZE")?> + <?=$config->getValue("/RTCS/" . $controller, "Y_SIZE")?>];
-<?    ?>float k_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>] = {<?=$config->getValue("/RTCS/" . $controller, "K_MATRIX")?>};
-<?    ?>float mf_data_<?=$count;?>[] = {<?=$config->getValue("/RTCS/" . $controller, "FUND_MATRIX")?>};
-<?    ?>float mt_data_<?=$count;?>[] = {<?=$config->getValue("/RTCS/" . $controller, "TRAN_MATRIX")?>};
+<?    ?>float x_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
+<?    ?>float xo_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
+<?    ?>float u_y_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "U_SIZE")?> + <?=$this->config->getValue("/RTCS/" . $controller, "Y_SIZE")?>];
+<?    ?>float k_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>] = {<?=$this->config->getValue("/RTCS/" . $controller, "K_MATRIX")?>};
+<?    ?>float mf_data_<?=$count;?>[] = {<?=$this->config->getValue("/RTCS/" . $controller, "FUND_MATRIX")?>};
+<?    ?>float mt_data_<?=$count;?>[] = {<?=$this->config->getValue("/RTCS/" . $controller, "TRAN_MATRIX")?>};
 <?    ?>Rtcs_ext_matrix_t matrix_array_<?=$count;?>[8];
-<?    ?>Rtcs_statefeedback_data_t controller_<?=$count;?> = {REGULATOR, FULL, <?=$config->getValue("/RTCS/" . $controller, "PERIOD")?>, 0, <?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>, 0, <?=$config->getValue("/RTCS/" . $controller, "U_SIZE")?>, <?=$config->getValue("/RTCS/" . $controller, "Y_SIZE")?>, 0, x_data_<?=$count?>, xo_data_<?=$count;?>, 0, u_y_data_<?=$count;?>, &(u_y_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "U_SIZE")?>]),k_data_<?=$count;?>, u_y_data_<?=$count;?>, 0, 0, 0, mf_data_<?=$count;?>, mt_data_<?=$count;?>, 0, 0, &matrix_array_<?=$count?>[0], &matrix_array_<?=$count?>[1], 0, &matrix_array_<?=$count?>[2], &matrix_array_<?=$count?>[3], &matrix_array_<?=$count?>[4], &matrix_array_<?=$count?>[5], 0, 0, 0, &matrix_array_<?=$count?>[6], &matrix_array_<?=$count?>[7], 0, <?=$config->getValue("/RTCS/" . $controller, "SEND_FUNCTION")?>, Rtcs_RegulatorControlEffort, Rtcs_FullObserver};
+<?    ?>Rtcs_statefeedback_data_t controller_<?=$count;?> = {REGULATOR, FULL, <?=$this->config->getValue("/RTCS/" . $controller, "PERIOD")?>, 0, <?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>, 0, <?=$this->config->getValue("/RTCS/" . $controller, "U_SIZE")?>, <?=$this->config->getValue("/RTCS/" . $controller, "Y_SIZE")?>, 0, x_data_<?=$count?>, xo_data_<?=$count;?>, 0, u_y_data_<?=$count;?>, &(u_y_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "U_SIZE")?>]),k_data_<?=$count;?>, u_y_data_<?=$count;?>, 0, 0, 0, mf_data_<?=$count;?>, mt_data_<?=$count;?>, 0, 0, &matrix_array_<?=$count?>[0], &matrix_array_<?=$count?>[1], 0, &matrix_array_<?=$count?>[2], &matrix_array_<?=$count?>[3], &matrix_array_<?=$count?>[4], &matrix_array_<?=$count?>[5], 0, 0, 0, &matrix_array_<?=$count?>[6], &matrix_array_<?=$count?>[7], 0, <?=$this->config->getValue("/RTCS/" . $controller, "SEND_FUNCTION")?>, Rtcs_RegulatorControlEffort, Rtcs_FullObserver};
 <?php endif
 
    ?>
 <?php
    /* system configuration if the system is "REGULATOR" and observer is "REDUCED" */
    if ($system_type == "REGULATOR" && $observer_type == "REDUCED"): ?>
-<?    ?>float x_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
-<?    ?>float xo_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?> - <?=$config->getValue("/RTCS/" . $controller, "Y_SIZE")?>];
-<?    ?>float y_u_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "Y_SIZE")?> + <?=$config->getValue("/RTCS/" . $controller, "U_SIZE")?>];
-<?    ?>float k_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>] = {<?=$config->getValue("/RTCS/" . $controller, "K_MATRIX")?>};
-<?    ?>float l_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?> - <?=$config->getValue("/RTCS/" . $controller, "Y_SIZE")?>] = {<?=$config->getValue("/RTCS/" . $controller, "L_MATRIX")?>};
-<?    ?>float mf_data_<?=$count;?>[] = {<?=$config->getValue("/RTCS/" . $controller, "FUND_MATRIX")?>};
-<?    ?>float mt_data_<?=$count;?>[] = {<?=$config->getValue("/RTCS/" . $controller, "TRAN_MATRIX")?>};
-<?    ?>float xo_aux_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?> - <?=$config->getValue("/RTCS/" . $controller, "Y_SIZE")?>];
+<?    ?>float x_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>];
+<?    ?>float xo_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?> - <?=$this->config->getValue("/RTCS/" . $controller, "Y_SIZE")?>];
+<?    ?>float y_u_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "Y_SIZE")?> + <?=$this->config->getValue("/RTCS/" . $controller, "U_SIZE")?>];
+<?    ?>float k_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>] = {<?=$this->config->getValue("/RTCS/" . $controller, "K_MATRIX")?>};
+<?    ?>float l_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?> - <?=$this->config->getValue("/RTCS/" . $controller, "Y_SIZE")?>] = {<?=$this->config->getValue("/RTCS/" . $controller, "L_MATRIX")?>};
+<?    ?>float mf_data_<?=$count;?>[] = {<?=$this->config->getValue("/RTCS/" . $controller, "FUND_MATRIX")?>};
+<?    ?>float mt_data_<?=$count;?>[] = {<?=$this->config->getValue("/RTCS/" . $controller, "TRAN_MATRIX")?>};
+<?    ?>float xo_aux_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?> - <?=$this->config->getValue("/RTCS/" . $controller, "Y_SIZE")?>];
 <?    ?>Rtcs_ext_matrix_t matrix_array_<?=$count;?>[10];
-<?    ?>Rtcs_statefeedback_data_t controller_<?=$count;?> = {REGULATOR, REDUCED, <?=$config->getValue("/RTCS/" . $controller, "PERIOD")?>, 0, <?=$config->getValue("/RTCS/" . $controller, "X_SIZE")?>, 0, <?=$config->getValue("/RTCS/" . $controller, "U_SIZE")?>, <?=$config->getValue("/RTCS/" . $controller, "Y_SIZE")?>, 0, x_data_<?=$count?>, xo_data_<?=$count;?>, 0, &(y_u_data_<?=$count;?>[<?=$config->getValue("/RTCS/" . $controller, "Y_SIZE")?>]), y_u_data_<?=$count;?>,k_data_<?=$count;?>, y_u_data_<?=$count;?>, 0, 0, l_data_<?=$count;?>, mf_data_<?=$count;?>, mt_data_<?=$count;?>, xo_aux_data_<?=$count;?>, 0, &matrix_array_<?=$count?>[0], &matrix_array_<?=$count?>[1], 0, &matrix_array_<?=$count?>[2], &matrix_array_<?=$count?>[3], &matrix_array_<?=$count?>[4], &matrix_array_<?=$count?>[5], 0, 0, &matrix_array_<?=$count?>[6], &matrix_array_<?=$count?>[7], &matrix_array_<?=$count?>[8], &matrix_array_<?=$count?>[9], <?=$config->getValue("/RTCS/" . $controller, "SEND_FUNCTION")?>, Rtcs_RegulatorControlEffort, Rtcs_ReducedObserver};
+<?    ?>Rtcs_statefeedback_data_t controller_<?=$count;?> = {REGULATOR, REDUCED, <?=$this->config->getValue("/RTCS/" . $controller, "PERIOD")?>, 0, <?=$this->config->getValue("/RTCS/" . $controller, "X_SIZE")?>, 0, <?=$this->config->getValue("/RTCS/" . $controller, "U_SIZE")?>, <?=$this->config->getValue("/RTCS/" . $controller, "Y_SIZE")?>, 0, x_data_<?=$count?>, xo_data_<?=$count;?>, 0, &(y_u_data_<?=$count;?>[<?=$this->config->getValue("/RTCS/" . $controller, "Y_SIZE")?>]), y_u_data_<?=$count;?>,k_data_<?=$count;?>, y_u_data_<?=$count;?>, 0, 0, l_data_<?=$count;?>, mf_data_<?=$count;?>, mt_data_<?=$count;?>, xo_aux_data_<?=$count;?>, 0, &matrix_array_<?=$count?>[0], &matrix_array_<?=$count?>[1], 0, &matrix_array_<?=$count?>[2], &matrix_array_<?=$count?>[3], &matrix_array_<?=$count?>[4], &matrix_array_<?=$count?>[5], 0, 0, &matrix_array_<?=$count?>[6], &matrix_array_<?=$count?>[7], &matrix_array_<?=$count?>[8], &matrix_array_<?=$count?>[9], <?=$this->config->getValue("/RTCS/" . $controller, "SEND_FUNCTION")?>, Rtcs_RegulatorControlEffort, Rtcs_ReducedObserver};
 <?php endif
 
    ?>

--- a/modules/tools/scripts/check_trailing_spaces.sh
+++ b/modules/tools/scripts/check_trailing_spaces.sh
@@ -1,4 +1,10 @@
+# remove this line when the generator gets stable
+#
+#   -and -not -wholename "./out/*" \
+#
+
 TRAILING=$(find . -type f \
+   -and -not -wholename "./out/*" \
    -and -not -wholename "./.git*" \
    -and -not -wholename "./externals*" \
    -and -not -name "*.png" \


### PR DESCRIPTION
Changes to many oil templates in order to accommodate to the refactoring of firmware.modules.rtos.
( Oil generator refactoring #29 )
Relaxing of trainling spaces checks on generator output.