### PR TITLE
ciaaPOSIX_usleep should work with values between 0 and 999999

### DIFF
--- a/modules/posix/src/ciaaPOSIX_unistd.c
+++ b/modules/posix/src/ciaaPOSIX_unistd.c
@@ -143,7 +143,7 @@ extern int32_t ciaaPOSIX_usleep(useconds_t useconds)
    uint32_t toSleep;
 
 #if (CIAAPOSIX_DEBUG == CIAAPOSIX_ENABLE)
-   if (1000000 >= useconds)
+   if (1000000 <= useconds)
    {
       ret = -1;
    }

--- a/modules/posix/test/utest/src/test_ciaaPOSIX_unistd.c
+++ b/modules/posix/test/utest/src/test_ciaaPOSIX_unistd.c
@@ -395,7 +395,7 @@ void test_ciaaPOSIX_usleep_01(void) {
    TEST_ASSERT_FALSE(ciaaPOSIX_sleepsTest[2]);
 
    /* Set initial condition for this test */
-   ret = ciaaPOSIX_usleep(1000001);
+   ret = ciaaPOSIX_usleep(999999);
 
    /* ASSERTs */
    /* return OK */
@@ -436,7 +436,7 @@ void test_ciaaPOSIX_usleep_02(void) {
    TEST_ASSERT_FALSE(ciaaPOSIX_sleepsTest[2]);
 
    /* Set initial condition for this test */
-   ret = ciaaPOSIX_usleep(999999);
+   ret = ciaaPOSIX_usleep(1000000);
 
    /* ASSERTs */
    /* return ERROR */


### PR DESCRIPTION
Me tomé la libertad de cambiar ciaaPOSIX_usleep a lo que creo que es el comportamiento esperado (ver issue #417 ), no estoy seguro si tiene que incluir el 1000000 o ser hasta 999999, pero lo dejo así.

Lo probé con una EDU-CIAA y funciona bien.