### PR TITLE
workaround multicore issue #445

### DIFF
--- a/modules/posix/src/ciaaPOSIX_stdlib.c
+++ b/modules/posix/src/ciaaPOSIX_stdlib.c
@@ -51,7 +51,7 @@
 
 /*==================[macros and definitions]=================================*/
 
-#define CIAA_HEAP_MEM_SIZE 20000
+#define CIAA_HEAP_MEM_SIZE 12000
 #define CIAA_POSIX_STDLIB_AVAILABLE 1
 #define CIAA_POSIX_STDLIB_USED 0
 


### PR DESCRIPTION
Reduce reserved memory heap size from 20000 to 12000.  This was necessary to prevent build errors in the multicore CortexM0 example.
This error comes when trying to build with `make mcore` right after solving the os generation issue #445 