### PR TITLE
New lwip souce link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/ciaa/firmware.modules.modbus.git
 [submodule "externals/lwip/lwip_src"]
 	path = externals/lwip/lwip_src
-	url = https://git.savannah.nongnu.org/git/lwip.git/
+	url = https://git.savannah.nongnu.org/git/lwip.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/ciaa/firmware.modules.modbus.git
 [submodule "externals/lwip/lwip_src"]
 	path = externals/lwip/lwip_src
-	url = git://git.savannah.nongnu.org/lwip.git
+	url = https://git.savannah.nongnu.org/git/lwip.git/


### PR DESCRIPTION
I propose to change the actual link of the lwip sources to a new one. The reason is a connection problem with git clients under http proxy and/or restrictive firewalls (for example, our jenkins server at UNS). After all, the official page offers the link https://git.savannah.nongnu.org/git/lwip.git as an annonymous clonning link of the sources. Note: this group has multiple Git repositories.

![lwip](https://user-images.githubusercontent.com/7976629/29376181-192d18b6-828e-11e7-91c6-ee3377f75228.png)

